### PR TITLE
Refactor pages into reusable components

### DIFF
--- a/vaultpro-ui/src/components/LoginForm.tsx
+++ b/vaultpro-ui/src/components/LoginForm.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { TextField, Button, Typography, Paper, Box } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import API from '../services/api';
+
+const LoginForm = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [require2FA, setRequire2FA] = useState(false);
+  const [codigo2FA, setCodigo2FA] = useState('');
+  const navigate = useNavigate();
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const response = await API.post('/auth/login', {
+        email,
+        password,
+        codigo2FA: codigo2FA || null,
+      });
+
+      localStorage.setItem('token', response.data.token);
+      alert('Login exitoso');
+      navigate('/dashboard');
+    } catch (error: any) {
+      if (error.response?.data?.require2fa) {
+        setRequire2FA(true);
+        alert('Este usuario requiere código 2FA');
+      } else {
+        alert('Credenciales inválidas');
+      }
+    }
+  };
+
+  return (
+    <Paper elevation={3} sx={{ p: 4 }}>
+      <Typography variant="h5" gutterBottom align="center">
+        Iniciar Sesión
+      </Typography>
+      <Box
+        component="form"
+        onSubmit={handleLogin}
+        display="flex"
+        flexDirection="column"
+        gap={2}
+      >
+        <TextField
+          label="Email"
+          fullWidth
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <TextField
+          label="Contraseña"
+          type="password"
+          fullWidth
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {require2FA && (
+          <TextField
+            label="Código 2FA"
+            fullWidth
+            value={codigo2FA}
+            onChange={(e) => setCodigo2FA(e.target.value)}
+          />
+        )}
+        <Button type="submit" variant="contained">
+          Ingresar
+        </Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export default LoginForm;

--- a/vaultpro-ui/src/components/RegisterForm.tsx
+++ b/vaultpro-ui/src/components/RegisterForm.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import {
+  TextField,
+  Button,
+  Typography,
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl,
+  Paper,
+  Box,
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { register } from '../services/authService';
+
+const RegisterForm = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [rol, setRol] = useState('User');
+  const navigate = useNavigate();
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await register(email, password, rol);
+      alert('Usuario registrado correctamente');
+      navigate('/');
+    } catch (error: any) {
+      const msg = error.response?.data?.message || 'Error al registrar usuario';
+      alert(msg);
+    }
+  };
+
+  return (
+    <Paper elevation={3} sx={{ p: 4 }}>
+      <Typography variant="h5" gutterBottom align="center">
+        Crear Cuenta
+      </Typography>
+      <Box
+        component="form"
+        onSubmit={handleRegister}
+        display="flex"
+        flexDirection="column"
+        gap={2}
+      >
+        <TextField
+          label="Email"
+          type="email"
+          fullWidth
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <TextField
+          label="Contraseña"
+          type="password"
+          fullWidth
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <FormControl fullWidth>
+          <InputLabel id="rol-label">Rol</InputLabel>
+          <Select
+            labelId="rol-label"
+            value={rol}
+            label="Rol"
+            onChange={(e) => setRol(e.target.value)}
+          >
+            <MenuItem value="User">Usuario</MenuItem>
+            <MenuItem value="Admin">Administrador</MenuItem>
+            <MenuItem value="Auditor">Auditor</MenuItem>
+          </Select>
+        </FormControl>
+        <Button type="submit" variant="contained">
+          Registrarme
+        </Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export default RegisterForm;

--- a/vaultpro-ui/src/components/TwoFactorSetup.tsx
+++ b/vaultpro-ui/src/components/TwoFactorSetup.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { Typography, CircularProgress, Box, Button, Paper } from '@mui/material';
+import { activar2FA } from '../services/authService';
+import { useNavigate } from 'react-router-dom';
+
+const TwoFactorSetup = () => {
+  const [secret, setSecret] = useState('');
+  const [qrCode, setQrCode] = useState('');
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    activar2FA()
+      .then((data) => {
+        setSecret(data.secret);
+        setQrCode(data.qrCodeBase64);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <CircularProgress />;
+
+  return (
+    <Paper elevation={3} sx={{ p: 4 }}>
+      <Typography variant="h5" gutterBottom>
+        Activar Autenticación 2FA
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        Escaneá este código QR con Google Authenticator u otra app TOTP.
+      </Typography>
+      <Box display="flex" justifyContent="center" my={3}>
+        <img src={qrCode} alt="QR Code 2FA" />
+      </Box>
+      <Typography variant="body2">O ingresá este código manualmente:</Typography>
+      <Typography variant="body1" fontWeight="bold" gutterBottom>
+        {secret}
+      </Typography>
+      <Button variant="contained" onClick={() => navigate('/dashboard')}>
+        Volver al Dashboard
+      </Button>
+    </Paper>
+  );
+};
+
+export default TwoFactorSetup;

--- a/vaultpro-ui/src/components/VaultForm.tsx
+++ b/vaultpro-ui/src/components/VaultForm.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import {
   TextField,
   Button,
-  Box
+  Box,
+  Paper,
 } from '@mui/material';
 
 interface Props {
@@ -23,12 +24,14 @@ const VaultForm: React.FC<Props> = ({ onSubmit }) => {
   };
 
   return (
-    <Box display="flex" gap={2} flexDirection="column" maxWidth={500}>
+    <Paper sx={{ p: 3 }}>
+      <Box display="flex" gap={2} flexDirection="column" maxWidth={500}>
       <TextField label="Nombre" value={nombre} onChange={(e) => setNombre(e.target.value)} />
       <TextField label="Usuario" value={nombreUsuario} onChange={(e) => setNombreUsuario(e.target.value)} />
       <TextField label="Contraseña" value={clave} onChange={(e) => setClave(e.target.value)} />
       <Button variant="contained" onClick={handleSubmit}>Guardar</Button>
-    </Box>
+      </Box>
+    </Paper>
   );
 };
 

--- a/vaultpro-ui/src/components/VaultList.tsx
+++ b/vaultpro-ui/src/components/VaultList.tsx
@@ -4,7 +4,8 @@ import {
   ListItem,
   Typography,
   IconButton,
-  Box
+  Box,
+  Paper,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { Contraseña } from '../services/passwordService';
@@ -15,25 +16,27 @@ interface Props {
 }
 
 const VaultList: React.FC<Props> = ({ contraseñas, onDelete }) => (
-  <List>
-    {contraseñas.map((c) => (
-      <ListItem
-        key={c.id}
-        secondaryAction={
-          <IconButton edge="end" onClick={() => onDelete(c.id)}>
-            <DeleteIcon />
-          </IconButton>
-        }
-      >
-        <Box>
-          <Typography fontWeight="bold">{c.nombre}</Typography>
-          <Typography variant="body2">
-            Usuario: {c.nombreUsuario} | Contraseña: {c.contraseña}
-          </Typography>
-        </Box>
-      </ListItem>
-    ))}
-  </List>
+  <Paper sx={{ p: 2 }}>
+    <List>
+      {contraseñas.map((c) => (
+        <ListItem
+          key={c.id}
+          secondaryAction={
+            <IconButton edge="end" onClick={() => onDelete(c.id)}>
+              <DeleteIcon />
+            </IconButton>
+          }
+        >
+          <Box>
+            <Typography fontWeight="bold">{c.nombre}</Typography>
+            <Typography variant="body2">
+              Usuario: {c.nombreUsuario} | Contraseña: {c.contraseña}
+            </Typography>
+          </Box>
+        </ListItem>
+      ))}
+    </List>
+  </Paper>
 );
 
 export default VaultList;

--- a/vaultpro-ui/src/pages/Activar2FAPage.tsx
+++ b/vaultpro-ui/src/pages/Activar2FAPage.tsx
@@ -1,44 +1,12 @@
-import { useEffect, useState } from 'react';
-import { Container, Typography, CircularProgress, Box, Button, Paper } from '@mui/material';
-import { activar2FA } from '../services/authService';
-import { useNavigate } from 'react-router-dom';
+import { Container, Box } from '@mui/material';
+import TwoFactorSetup from '../components/TwoFactorSetup';
 
-const Activar2FAPage = () => {
-  const [secret, setSecret] = useState('');
-  const [qrCode, setQrCode] = useState('');
-  const [loading, setLoading] = useState(true);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    activar2FA()
-      .then((data) => {
-        setSecret(data.secret);
-        setQrCode(data.qrCodeBase64);
-      })
-      .finally(() => setLoading(false));
-  }, []);
-
-  if (loading) return <CircularProgress />;
-
-  return (
-    <Container maxWidth="sm">
-      <Paper elevation={3} sx={{ padding: 4, marginTop: 4 }}>
-        <Typography variant="h5" gutterBottom>Activar Autenticación 2FA</Typography>
-        <Typography variant="body1" gutterBottom>
-          Escaneá este código QR con Google Authenticator u otra app TOTP.
-        </Typography>
-
-        <Box display="flex" justifyContent="center" my={3}>
-          <img src={qrCode} alt="QR Code 2FA" />
-        </Box>
-
-        <Typography variant="body2">O ingresá este código manualmente:</Typography>
-        <Typography variant="body1" fontWeight="bold" gutterBottom>{secret}</Typography>
-
-        <Button variant="contained" onClick={() => navigate('/dashboard')}>Volver al Dashboard</Button>
-      </Paper>
-    </Container>
-  );
-};
+const Activar2FAPage = () => (
+  <Container maxWidth="sm">
+    <Box mt={4}>
+      <TwoFactorSetup />
+    </Box>
+  </Container>
+);
 
 export default Activar2FAPage;

--- a/vaultpro-ui/src/pages/LoginPage.tsx
+++ b/vaultpro-ui/src/pages/LoginPage.tsx
@@ -1,73 +1,12 @@
-import { useState } from 'react';
-import { TextField, Button, Container, Typography } from '@mui/material';
-import API from '../services/api';
-import { useNavigate } from 'react-router-dom';
+import { Container, Box } from '@mui/material';
+import LoginForm from '../components/LoginForm';
 
-const LoginPage = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [require2FA, setRequire2FA] = useState(false);
-  const [codigo2FA, setCodigo2FA] = useState('');
-  const navigate = useNavigate();
-
-
-  const handleLogin = async () => {
-    try {
-      const response = await API.post('/auth/login', {
-        email,
-        password,
-        codigo2FA: codigo2FA || null
-      });
-      console.log('Login response:', response.data);
-      
-      localStorage.setItem('token', response.data.token);
-      alert('Login exitoso');
-      navigate('/dashboard');
-
-    } catch (error: any) {
-      if (error.response?.data?.require2fa) {
-        setRequire2FA(true);
-        alert('Este usuario requiere código 2FA');
-      } else {
-        alert('Credenciales inválidas');
-      }
-    }
-
-  };
-
-  return (
-    <Container maxWidth="sm">
-      <Typography variant="h4" gutterBottom>Iniciar Sesión</Typography>
-      <form onSubmit={handleLogin}>
-        <TextField
-          label="Email"
-          fullWidth
-          margin="normal"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <TextField
-          label="Contraseña"
-          type="password"
-          fullWidth
-          margin="normal"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        {require2FA && (
-          <TextField
-            label="Código 2FA"
-            fullWidth
-            margin="normal"
-            value={codigo2FA}
-            onChange={(e) => setCodigo2FA(e.target.value)}
-          />
-        )}
-
-        <Button type="submit" variant="contained" color="primary">Ingresar</Button>
-      </form>
-    </Container>
-  );
-};
+const LoginPage = () => (
+  <Container maxWidth="sm">
+    <Box mt={4}>
+      <LoginForm />
+    </Box>
+  </Container>
+);
 
 export default LoginPage;

--- a/vaultpro-ui/src/pages/RegisterPage.tsx
+++ b/vaultpro-ui/src/pages/RegisterPage.tsx
@@ -1,87 +1,12 @@
-import React, { useState } from 'react';
-import {
-  TextField,
-  Button,
-  Container,
-  Typography,
-  Select,
-  MenuItem,
-  InputLabel,
-  FormControl,
-  Box,
-  Paper
-} from '@mui/material';
-import { register } from '../services/authService';
-import { useNavigate } from 'react-router-dom';
+import { Container, Box } from '@mui/material';
+import RegisterForm from '../components/RegisterForm';
 
-const RegisterPage = () => {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [rol, setRol] = useState('User');
-  const navigate = useNavigate();
-
-  const handleRegister = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-      await register(email, password, rol);
-      alert('Usuario registrado correctamente');
-      navigate('/');
-    } catch (error: any) {
-      const msg = error.response?.data?.message || 'Error al registrar usuario';
-      alert(msg);
-    }
-  };
-
-  return (
-    <Container maxWidth="sm">
-      <Paper elevation={3} sx={{ padding: 4, marginTop: 4 }}>
-        <Typography variant="h4" gutterBottom align="center">
-          Crear Cuenta
-        </Typography>
-        <form onSubmit={handleRegister}>
-          <TextField
-            label="Email"
-            fullWidth
-            margin="normal"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-
-          <TextField
-            label="Contraseña"
-            type="password"
-            fullWidth
-            margin="normal"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-
-          <FormControl fullWidth margin="normal">
-            <InputLabel id="rol-label">Rol</InputLabel>
-            <Select
-              labelId="rol-label"
-              value={rol}
-              label="Rol"
-              onChange={(e) => setRol(e.target.value)}
-            >
-              <MenuItem value="User">Usuario</MenuItem>
-              <MenuItem value="Admin">Administrador</MenuItem>
-              <MenuItem value="Auditor">Auditor</MenuItem>
-            </Select>
-          </FormControl>
-
-          <Box mt={3}>
-            <Button type="submit" fullWidth variant="contained" color="primary">
-              Registrarme
-            </Button>
-          </Box>
-        </form>
-      </Paper>
-    </Container>
-  );
-};
+const RegisterPage = () => (
+  <Container maxWidth="sm">
+    <Box mt={4}>
+      <RegisterForm />
+    </Box>
+  </Container>
+);
 
 export default RegisterPage;


### PR DESCRIPTION
## Summary
- restructure pages to use new components
- add LoginForm and RegisterForm
- make 2FA setup a component
- wrap VaultForm and VaultList with Paper for nicer style

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68477f6ddfc883228aecb549bbd7abce